### PR TITLE
Avoid Dockerfile rate limiting by using Amazon ECR Public Gallery for python image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.2-slim
+FROM public.ecr.aws/docker/library/python:3.11-slim
 
 RUN pip install poetry
 RUN mkdir diff_poetry_lock


### PR DESCRIPTION
We were getting rate limited in our actions and this fixed it for us