### PR TITLE
Updates dockerfile to ensure installed poetry version is below 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11.2-slim
 
-RUN pip install poetry
+RUN pip install "poetry>=1,<2.0"
 RUN mkdir diff_poetry_lock
 COPY diff_poetry_lock/* ./diff_poetry_lock/
 COPY poetry.lock ./diff_poetry_lock/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Diff poetry.lock"
-version = "1.0.0"
+version = "1.1.0"
 description = "A Github Action that posts a summary of all changes within the poetry.lock file to a pull request"
 authors = ["Nils Borrmann"]
 readme = "README.md"


### PR DESCRIPTION
The release of [poetry 2.0](https://github.com/python-poetry/poetry/releases/tag/2.0.0) has broken the dockerfile that underpins this github action.

What was previously a `warning` only, has now becomes an `error` causing the docker build to fail.

The `warning` is caused by a missing `readme` file; which has no functional bearing on the action itself but is a byproduct of calling `poetry install`.

This PR:

* fixes the poetry version to be below `poetry>=1,<2.0`
* ups the package version number in `pyproject.toml` to `1.1.0` indicating a minor change

Suggestion: create a fixed tag for this repository at `1.1.0` such that people can pin to this working version.

Future suggestion: After fixing the issues with poetry 2.0, create a tag `2.0.0` as the basis for continued development.